### PR TITLE
feat: introduce new kaomojis

### DIFF
--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,3 @@
+[default.extend-identifiers]
+tere = "tere"
+

--- a/lua/cmp_kaomoji/kaomoji.lua
+++ b/lua/cmp_kaomoji/kaomoji.lua
@@ -1,5 +1,5 @@
----@see: https://microsoft.github.io/language-server-protocol/specifications/specification-current/
----@see: https://github.com/hrsh7th/nvim-cmp/blob/v0.0.2/lua/cmp/types/lsp.lua#L265-L285
+---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/
+---@see https://github.com/hrsh7th/nvim-cmp/blob/v0.0.2/lua/cmp/types/lsp.lua#L265-L285
 local kaomoji_list = {
   -- Action
   {
@@ -197,6 +197,11 @@ local kaomoji_list = {
     _tags = { 'fight', 'determined', 'battle' },
     _category = 'action',
   },
+  {
+    word = ':wink_1:',
+    label = '(＜ゝω・)',
+    _category = 'emotion',
+  },
 
   -- Animal: bear
   {
@@ -228,6 +233,12 @@ local kaomoji_list = {
   {
     word = ':shy_bear_1:',
     label = 'ʕ￫ᴥ￩ʔ',
+    _category = 'animal',
+  },
+  {
+    word = ':sleepy_bear_1:',
+    label = 'ʕ´-ﻌก̀ʔᐝ',
+    _tags = { 'tired', 'sleepy' },
     _category = 'animal',
   },
   -- Animal: cat
@@ -446,6 +457,12 @@ local kaomoji_list = {
     word = ':encourage_4:',
     label = '৻( •̀ ᗜ •́ ৻)',
     _tags = { 'cheering', 'fighting' },
+    _category = 'emotion',
+  },
+  {
+    word = ':encourage_5:',
+    label = 'ଘ(੭*ˊᵕˋ)੭',
+    _tags = { 'cheering', 'fighting', 'angel' },
     _category = 'emotion',
   },
   {


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Adds new kaomojis**
> 
> - Introduces `:wink_1:` (emotion), `:sleepy_bear_1:` (animal), and `:encourage_5:` (emotion) in `lua/cmp_kaomoji/kaomoji.lua`
> 
> **Tooling/config**
> 
> - Adds `_typos.toml` with identifier override for `tere`
> 
> **Misc**
> 
> - Cleans up `---@see` comment annotations at file header
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ffcd19442ded13e33c5d6475e6980cf625da7f61. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->